### PR TITLE
Update the proto comments to explain when idevid is used and clarify cert chain expectation

### DIFF
--- a/proto/tpm_attestz.proto
+++ b/proto/tpm_attestz.proto
@@ -76,8 +76,8 @@ message AttestResponse {
   bytes quote_signature = 5;
 
   // [Optional] PEM-encoded owner initial DevID certificate signed by the
-  // switch owner/administrator CA. This field should only be populated for
-  // standby/secondary control card.
+  // switch owner/administrator CA. This field may only be populated for
+  // the standby/secondary control card.
   string oidevid_cert = 6;
 }
 

--- a/proto/tpm_attestz.proto
+++ b/proto/tpm_attestz.proto
@@ -52,7 +52,9 @@ message AttestResponse {
   ControlCardVendorId control_card_id = 1;
 
   // PEM-encoded owner initial attestation key certificate signed by the switch
-  // owner/administrator CA during TPM enrollment workflow.
+  // owner/administrator CA during TPM enrollment workflow. The PEM formatted 
+  // cert string can have more than one certificate block representing a
+  // certificate chain.
   string oiak_cert = 2;
 
   // Final observed unsigned PCR values {pcr_index -> pcr_value}.
@@ -77,7 +79,8 @@ message AttestResponse {
 
   // [Optional] PEM-encoded owner initial DevID certificate signed by the
   // switch owner/administrator CA. This field may only be populated for
-  // the standby/secondary control card.
+  // the standby/secondary control card. The PEM formatted cert string can have
+  // more than one certificate block representing a certificate chain.
   string oidevid_cert = 6;
 }
 

--- a/proto/tpm_enrollz.proto
+++ b/proto/tpm_enrollz.proto
@@ -53,12 +53,18 @@ message RotateOIakCertRequest {
   ControlCardSelection control_card_selection = 1;
 
   // PEM-encoded owner initial attestation key certificate signed by the
-  // switch owner/administrator CA.
+  // switch owner/administrator CA. The PEM formatted cert string can have
+  // more than one certificate block representing a certificate chain.
   string oiak_cert = 2;
 
   // [Optional] PEM-encoded owner initial DevID certificate signed by the
-  // switch owner/administrator CA. Will be empty if `idevid_cert` was not
-  // provided in GetIakCertResponse earlier in the workflow.
+  // switch owner/administrator CA. The PEM formatted cert string can have
+  // more than one certificate block representing a certificate chain.
+  //
+  // Will be unassigned in these workflows:
+  // 1. During oIak Installation, if `idevid_cert` was not
+  // provided in GetIakCertResponse.
+  // 2. During oIak Rotation.
   string oidevid_cert = 3;
 
   // SSL profile for which the certs will be assigned.

--- a/proto/tpm_enrollz.proto
+++ b/proto/tpm_enrollz.proto
@@ -56,8 +56,9 @@ message RotateOIakCertRequest {
   // switch owner/administrator CA.
   string oiak_cert = 2;
 
-  // PEM-encoded owner initial DevID certificate signed by the
-  // switch owner/administrator CA.
+  // [Optional] PEM-encoded owner initial DevID certificate signed by the
+  // switch owner/administrator CA. Will be empty if `idevid_cert` was not
+  // provided in GetIakCertResponse earlier in the workflow.
   string oidevid_cert = 3;
 
   // SSL profile for which the certs will be assigned.


### PR DESCRIPTION
There are instances where we rotate on Google certs earlier in the workflow instead of using devid. For flexibility, make it clear that the devid is an optional field.