### PR TITLE
removing ROTDBClient from the EnrollzInfraDeps

### DIFF
--- a/service/biz/enrollz_biz.go
+++ b/service/biz/enrollz_biz.go
@@ -154,9 +154,6 @@ type EnrollzInfraDeps interface {
 
 	// Parser and verifier of IAK and IDevID certs.
 	TpmCertVerifier
-
-	// Client to fetch the EK Public Key from the RoT database.
-	ROTDBClient
 }
 
 // RotateAIKCertInfraDeps is the infra-specific dependencies of the RotateAIKCert business logic.

--- a/service/biz/enrollz_biz_test.go
+++ b/service/biz/enrollz_biz_test.go
@@ -41,7 +41,6 @@ type stubEnrollzInfraDeps struct {
 	SwitchOwnerCaClient
 	EnrollzDeviceClient
 	TpmCertVerifier
-	ROTDBClient
 
 	// Request params that would be captured in stubbed deps' function calls.
 	issueOwnerIakCertReq       *IssueOwnerIakCertReq


### PR DESCRIPTION
Removing ROTDBClient from the EnrollzInfraDeps as it is part of the RotateAIKDeps now since it is only related to the TPM 1.2 WF