### PR TITLE
change aes key generation and encryption to cbc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,4 +14,4 @@ go_sdk.download(version = "1.25.0")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
-use_repo(go_deps, "com_github_golang_glog", "com_github_google_go_cmp", "org_golang_google_grpc", "com_github_google_tink_go", "org_golang_google_grpc_cmd_protoc_gen_go_grpc", "org_golang_google_protobuf", "com_github_google_go_tpm")
+use_repo(go_deps, "com_github_golang_glog", "com_github_google_go_cmp", "org_golang_google_grpc", "org_golang_google_grpc_cmd_protoc_gen_go_grpc", "org_golang_google_protobuf", "com_github_google_go_tpm")

--- a/_typos.toml
+++ b/_typos.toml
@@ -9,7 +9,9 @@ check-file = false
 [default.extend-words]
 "Parms" = "Parms"
 "PARMS" = "PARMS"
+"Encrypter" = "Encrypter"
 
 [default.extend-identifiers]
 "Parms" = "Parms"
 "PARMS" = "PARMS"
+"Encrypter" = "Encrypter"

--- a/attestz_go_deps.bzl
+++ b/attestz_go_deps.bzl
@@ -241,9 +241,3 @@ def attestz_go_deps():
         sum = "h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=",
         version = "v0.0.0-20191204190536-9bdfabe68543",
     )
-    go_repository(
-        name = "com_github_google_tink",
-        importpath = "github.com/google/tink/go",
-        sum = "h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=",
-        version = "v1.17.0",
-    )

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,12 @@ require (
 	github.com/golang/glog v1.2.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-tpm v0.9.5
-	github.com/google/tink/go v1.7.0
 	google.golang.org/grpc v1.75.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
 	google.golang.org/protobuf v1.36.8
 )
 
 require (
-	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/google/go-tpm v0.9.5 h1:ocUmnDebX54dnW+MQWGQRbdaAcJELsa6PqZhJ48KwVU=
 github.com/google/go-tpm v0.9.5/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba h1:qJEJcuLzH5KDR0gKc0zcktin6KSAwL7+jWKBYceddTc=
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
-github.com/google/tink/go v1.7.0 h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=
-github.com/google/tink/go v1.7.0/go.mod h1:GAUOd+QE3pgj9q8VKIGTCP33c/B7eb4NhxLcgTJZStM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -28,8 +26,6 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
-golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=

--- a/service/biz/BUILD.bazel
+++ b/service/biz/BUILD.bazel
@@ -111,9 +111,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_google_go_tpm//tpm",
-        "@com_github_google_tink_go//aead",
-        "@com_github_google_tink_go//keyset",
-        "@com_github_google_tink_go//insecurecleartextkeyset",
     ],
 )
 
@@ -127,7 +124,6 @@ go_test(
     deps = [
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_tpm//tpm",
-        "@com_github_google_tink_go//aead",
     ],
 )
 


### PR DESCRIPTION
- Switched AES key generation and encryption to CBC due to TPM 1.2 software limitations
- Returning TPMKeyParms in the encryption function so we can use it in the future to construct [TPM_SYM_CA_ATTESTATION](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Main-Part-2-TPM-Structures_v1.2_rev116_01032011.pdf#page=121)