### PR TITLE
Fixing bug for malformed ConstructIdentityContents()

### DIFF
--- a/service/biz/enrollz_biz.go
+++ b/service/biz/enrollz_biz.go
@@ -594,7 +594,7 @@ func RotateAIKCert(ctx context.Context, req *RotateAIKCertReq) error {
 	}
 
 	// Construct TPM_IDENTITY_CONTENTS
-	identityContents, err := req.Deps.ConstructIdentityContents(issuerPublicKey)
+	identityContents, err := req.Deps.ConstructIdentityContents(issuerPublicKey, &identityProof.AttestationIdentityKey)
 	if err != nil {
 		return fmt.Errorf("failed to construct identity contents: %w", err)
 	}

--- a/service/biz/enrollz_biz_test.go
+++ b/service/biz/enrollz_biz_test.go
@@ -958,7 +958,7 @@ func (s *stubRotateAIKCertInfraDeps) DecryptWithSymmetricKey(ctx context.Context
 	return []byte("decrypted identity proof"), nil // Default success
 }
 
-func (s *stubRotateAIKCertInfraDeps) ConstructIdentityContents(*rsa.PublicKey) (*TPMIdentityContents, error) {
+func (s *stubRotateAIKCertInfraDeps) ConstructIdentityContents(*rsa.PublicKey, *TPMPubKey) (*TPMIdentityContents, error) {
 	if s.constructIdentityContentsErr != nil {
 		return nil, s.constructIdentityContentsErr
 	}

--- a/service/biz/tpm12_utils.go
+++ b/service/biz/tpm12_utils.go
@@ -221,7 +221,7 @@ type TPM12Utils interface {
 	SerializePubKey(pubKey *TPMPubKey) ([]byte, error)
 	SerializeIdentityContents(identityContents *TPMIdentityContents) ([]byte, error)
 	ConstructPubKey(publicKey *rsa.PublicKey) (*TPMPubKey, error)
-	ConstructIdentityContents(publicKey *rsa.PublicKey) (*TPMIdentityContents, error)
+	ConstructIdentityContents(publicKey *rsa.PublicKey, aikPubKey *TPMPubKey) (*TPMIdentityContents, error)
 	ConstructAsymCAContents(symKey *TPMSymmetricKey, identityKey *TPMPubKey) (*TPMAsymCAContents, error)
 	SerializeAsymCAContents(asymCAContents *TPMAsymCAContents) ([]byte, error)
 	SerializeSymmetricKey(symKey *TPMSymmetricKey) ([]byte, error)
@@ -1165,7 +1165,7 @@ func (u *DefaultTPM12Utils) ConstructPubKey(publicKey *rsa.PublicKey) (*TPMPubKe
 }
 
 // ConstructIdentityContents constructs the TPM_IDENTITY_CONTENTS structure.
-func (u *DefaultTPM12Utils) ConstructIdentityContents(publicKey *rsa.PublicKey) (*TPMIdentityContents, error) {
+func (u *DefaultTPM12Utils) ConstructIdentityContents(publicKey *rsa.PublicKey, aikPubKey *TPMPubKey) (*TPMIdentityContents, error) {
 	tpmPubKey, err := u.ConstructPubKey(publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct TPMPubKey: %w", err)
@@ -1191,6 +1191,6 @@ func (u *DefaultTPM12Utils) ConstructIdentityContents(publicKey *rsa.PublicKey) 
 		TPMStructVer:      GetDefaultTPMStructVer(),
 		Ordinal:           0x00000079,
 		LabelPrivCADigest: labelPrivCADigest,
-		IdentityPubKey:    *tpmPubKey,
+		IdentityPubKey:    *aikPubKey,
 	}, nil
 }


### PR DESCRIPTION
Adding a pointer to the TPMPUBKEY as a parameter for the ConstructIndentityContents() function as per the TCG spec