### PR TITLE
Handle empty ciphertext in TPM 1.2 decryption

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = parms

--- a/service/biz/enrollz_biz_test.go
+++ b/service/biz/enrollz_biz_test.go
@@ -1143,10 +1143,6 @@ func TestRotateOwnerIakCert(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 type stubRotateAIKCertInfraDeps struct {
 	SwitchOwnerCaClient
 	EnrollzDeviceClient

--- a/service/biz/tpm12_utils.go
+++ b/service/biz/tpm12_utils.go
@@ -64,6 +64,8 @@ var (
 	ErrUnsupportedScheme = errors.New("unsupported scheme")
 	// ErrInvalidPadding is returned when there padding used is invalid.
 	ErrInvalidPadding = errors.New("invalid padding")
+	// ErrEmptyCiphertext is returned when the ciphertext is empty.
+	ErrEmptyCiphertext = errors.New("ciphertext is empty")
 )
 
 // Note: All the uint values in TPM_* structures in this file use big endian (network byte order).
@@ -808,7 +810,10 @@ func (u *DefaultTPM12Utils) DecryptWithSymmetricKey(ctx context.Context, symKey 
 		ciphertext = ciphertext[cipherBlock.BlockSize():]
 	}
 
-	// The ciphertext must be a multiple of the block size.
+	// The ciphertext must be a non-empty multiple of the block size.
+	if len(ciphertext) == 0 {
+		return nil, ErrEmptyCiphertext
+	}
 	if len(ciphertext)%cipherBlock.BlockSize() != 0 {
 		return nil, fmt.Errorf("ciphertext is not a multiple of the block size")
 	}

--- a/service/biz/tpm12_utils_test.go
+++ b/service/biz/tpm12_utils_test.go
@@ -2367,6 +2367,20 @@ func TestDecryptWithSymmetricKey_Failure(t *testing.T) {
 			data:          validCiphertext,
 			expectedError: ErrInvalidPadding,
 		},
+		{
+			name:          "Failure Empty Ciphertext External IV",
+			key:           keyBytes,
+			keyParams:     keyParams,
+			data:          []byte{},
+			expectedError: ErrEmptyCiphertext,
+		},
+		{
+			name:          "Failure Ciphertext Just IV",
+			key:           keyBytes,
+			keyParams:     &TPMKeyParms{EncScheme: EsSymCBCPKCS5},
+			data:          validCiphertext[:aes.BlockSize],
+			expectedError: ErrEmptyCiphertext,
+		},
 	}
 
 	for _, tc := range failureTestCases {

--- a/service/biz/tpm_cert_verifier_test.go
+++ b/service/biz/tpm_cert_verifier_test.go
@@ -945,39 +945,3 @@ func TestVerifyTpmCert(t *testing.T) {
 		})
 	}
 }
-
-func generateRSAKeyPair(t *testing.T, keySize int) (*rsa.PrivateKey, string) {
-	t.Helper()
-	privKey, err := rsa.GenerateKey(rand.Reader, keySize)
-	if err != nil {
-		t.Fatalf("Failed to generate RSA key: %v", err)
-	}
-	derBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
-	if err != nil {
-		t.Fatalf("Failed to marshal RSA public key: %v", err)
-	}
-	pubKeyPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "PUBLIC KEY",
-			Bytes: derBytes,
-		})
-	return privKey, string(pubKeyPem)
-}
-
-func generateECDSAKeyPair(t *testing.T, curve elliptic.Curve) (*ecdsa.PrivateKey, string) {
-	t.Helper()
-	privKey, err := ecdsa.GenerateKey(curve, rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate ECDSA key: %v", err)
-	}
-	derBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
-	if err != nil {
-		t.Fatalf("Failed to marshal ECDSA public key: %v", err)
-	}
-	pubKeyPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "PUBLIC KEY",
-			Bytes: derBytes,
-		})
-	return privKey, string(pubKeyPem)
-}


### PR DESCRIPTION
## Description
This PR adds safety checks to prevent panics and unexpected behavior during TPM 1.2 decryption when the ciphertext payload is empty. 

Specifically:
- Returns `ErrEmptyCiphertext` in `DecryptWithSymmetricKey` if the ciphertext is empty after extracting/processing the initialization vector (IV).
- Prevents potential out-of-bounds index panics when attempting to unpad empty plaintexts.

## Testing
- Added new failure unit test cases in `TestDecryptWithSymmetricKey_Failure` covering both empty ciphertext input and input that contains only the IV block.
- Verified all tests pass successfully in `service/biz`.
