### PR TITLE
Move ExtKeyUsageAny setting outside intermediates check in TPM cert verified

### DIFF
--- a/service/biz/tpm_cert_verifier.go
+++ b/service/biz/tpm_cert_verifier.go
@@ -268,8 +268,12 @@ func VerifyAndParsePemCert(ctx context.Context, certPem string, certVerification
 		for _, cert := range certs[1:] {
 			certVerificationOpts.Intermediates.AddCert(cert)
 		}
-		certVerificationOpts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
 	}
+
+	// TODO: Move this configuration to the caller. Add more granular verification option per-cert type rather than having blanket ExtKeyUsageAny.
+	// We relax the key usage requirement to ExtKeyUsageAny here because
+	// IAKs are not standard TLS endpoints and might not have standard TLS usages.
+	certVerificationOpts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
 
 	// Validate cert expiration and verify signature using provided options.
 	if _, err := leafCert.Verify(certVerificationOpts); err != nil {


### PR DESCRIPTION
Moves the x509.ExtKeyUsageAny setting in VerifyOptions outside the intermediates check in VerifyAndParsePemCert, ensuring it applies unconditionally to avoid breaking enrollment for single-certificate inputs.

Temp fix for vulnerability:
The VerifyAndParsePemCert function in service/biz/tpm_cert_verifier.go unconditionally overrides certVerificationOpts.KeyUsages to ExtKeyUsageAny when the device-supplied PEM input contains more than one certificate block (line 297). A device participating in TPM enrollment can include an additional PEM block to trigger this code path, causing certificate verification to accept certificates issued for any purpose (e.g., code signing, email protection) rather than enforcing the default ExtKeyUsageServerAuth restriction. This could allow an unauthorized device holding a cross-purpose certificate from a trusted CA to pass identity verification and complete TPM enrollment.

Root Cause
The KeyUsages override to ExtKeyUsageAny is coupled to the intermediate certificate pool construction inside the len(certs) > 1 conditional block at line 297. These are two independent operations — adding intermediates for chain validation and setting the ExtKeyUsage policy — but they are tied to the same attacker-controlled toggle (number of PEM blocks in the device response), creating an inconsistent validation policy based on untrusted input.