### PR TITLE
Add IAK public key attribute and AuthPolicy validations for TPM 2.0

### DIFF
--- a/service/biz/tpm20_utils.go
+++ b/service/biz/tpm20_utils.go
@@ -370,10 +370,32 @@ func (u *DefaultTPM20Utils) VerifyHMAC(message []byte, signature []byte, hmacSen
 	return nil
 }
 
+// expectedPolicySecretSHA256 and expectedPolicySecretSHA384 are the expected digests of the AuthPolicy for the IAK.
+// These specific policy digests correspond to TPM2_PolicySecret(TPM_RH_ENDORSEMENT) (often referred to as PolicyA in TCG EK Credential Profile).
+var (
+	expectedPolicySecretSHA256 = []byte{
+		0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
+		0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
+		0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
+		0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
+	}
+	expectedPolicySecretSHA384 = []byte{
+		0x12, 0x9D, 0x94, 0xEB, 0xF8, 0x45, 0x56, 0x65,
+		0x2C, 0x6E, 0xEF, 0x43, 0xBB, 0xB7, 0x57, 0x51,
+		0x2A, 0xC8, 0x7E, 0x52, 0xBE, 0x7B, 0x34, 0x9C,
+		0xA6, 0xCE, 0x4D, 0x82, 0x6F, 0x74, 0x9F, 0xCF,
+		0x67, 0x2F, 0x51, 0x71, 0x6C, 0x5C, 0xBB, 0x60,
+		0x5F, 0x31, 0x3B, 0xF3, 0x45, 0xAA, 0xB3, 0x12,
+	}
+)
+
 // VerifyCertifyInfo verifies the certify info (TPM2B_ATTEST) and the nested TPMS_CERTIFY_INFO structure.
 func (u *DefaultTPM20Utils) VerifyCertifyInfo(certifyInfoAttest *tpm20.TPMSAttest, certifiedKey *tpm20.TPMTPublic) error {
 	if certifyInfoAttest == nil {
-		return fmt.Errorf("certifyInfoAttest cannot be nil")
+		return fmt.Errorf("%w: certifyInfoAttest cannot be nil", ErrInputNil)
+	}
+	if certifiedKey == nil {
+		return fmt.Errorf("%w: certifiedKey cannot be nil", ErrInputNil)
 	}
 	if certifyInfoAttest.Magic != tpm20.TPMGeneratedValue {
 		return fmt.Errorf("%w: unexpected TPM2B_ATTEST magic %0x", ErrInvalidCertifyInfo, certifyInfoAttest.Magic)
@@ -405,7 +427,10 @@ func (u *DefaultTPM20Utils) VerifyCertifyInfo(certifyInfoAttest *tpm20.TPMSAttes
 	return nil
 }
 
-func verifyTPMTPublicAttributes(pubKey tpm20.TPMTPublic, expectedObjAttributes tpm20.TPMAObject) error {
+func verifyTPMTPublicAttributes(pubKey *tpm20.TPMTPublic, expectedObjAttributes tpm20.TPMAObject) error {
+	if pubKey == nil {
+		return fmt.Errorf("%w: pubKey cannot be nil", ErrInputNil)
+	}
 	if pubKey.ObjectAttributes.FixedTPM != expectedObjAttributes.FixedTPM {
 		return fmt.Errorf("%w: FixedTPM mismatch, got %v, want %v", ErrInvalidPubKeyAttributes, pubKey.ObjectAttributes.FixedTPM, expectedObjAttributes.FixedTPM)
 	}
@@ -443,6 +468,9 @@ func (u *DefaultTPM20Utils) VerifyIAKAttributes(iakPub []byte) (*tpm20.TPMTPubli
 	if err != nil {
 		return nil, fmt.Errorf("failed to get IAK public key contents: %w", err)
 	}
+	if iakPubKey == nil {
+		return nil, fmt.Errorf("%w: iakPubKey contents is nil", ErrInputNil)
+	}
 
 	// expectedObjAttributes defines the required properties for a TPM-based Attestation Key (IAK).
 	// These attributes ensure the key is a restricted signing key, as specified in
@@ -458,12 +486,55 @@ func (u *DefaultTPM20Utils) VerifyIAKAttributes(iakPub []byte) (*tpm20.TPMTPubli
 		AdminWithPolicy:     true,
 	}
 
-	if err := verifyTPMTPublicAttributes(*iakPubKey, expectedObjAttributes); err != nil {
+	if err := verifyTPMTPublicAttributes(iakPubKey, expectedObjAttributes); err != nil {
 		return nil, fmt.Errorf("failed to verify IAK attributes: %w", err)
 	}
 
-	if iakPubKey.NameAlg != tpm20.TPMAlgSHA256 && iakPubKey.NameAlg != tpm20.TPMAlgSHA384 {
-		return nil, fmt.Errorf("%w: IAKPub.NameAlg (%v) must be one of TPMAlgSHA256, TPMAlgSHA384, or TPMAlgSHA512", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
+	var expectedPolicySecret []byte
+	switch iakPubKey.Type {
+	case tpm20.TPMAlgRSA:
+		if iakPubKey.NameAlg != tpm20.TPMAlgSHA256 {
+			return nil, fmt.Errorf("%w: TPMAlgRSA IAKPub must use NameAlg TPMAlgSHA256, got %v", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
+		}
+		rsaParams, err := iakPubKey.Parameters.RSADetail()
+		if err != nil {
+			return nil, fmt.Errorf("%w: iakPubKey.Parameters are not RSAParams: %v", ErrInvalidPubKeyAttributes, err)
+		}
+		if rsaParams.KeyBits != 2048 {
+			return nil, fmt.Errorf("%w: unexpected rsaParams.KeyBits in iakPubKey got %v, want 2048", ErrInvalidPubKeyAttributes, rsaParams.KeyBits)
+		}
+		if rsaParams.Scheme.Scheme != tpm20.TPMAlgRSASSA {
+			return nil, fmt.Errorf("%w: unexpected rsaParams.Scheme.Scheme in iakPubKey got %v, want %v", ErrInvalidPubKeyAttributes, rsaParams.Scheme.Scheme, tpm20.TPMAlgRSASSA)
+		}
+		expectedPolicySecret = expectedPolicySecretSHA256
+	case tpm20.TPMAlgECC:
+		eccParams, err := iakPubKey.Parameters.ECCDetail()
+		if err != nil {
+			return nil, fmt.Errorf("%w: iakPubKey.Parameters are not ECCParams: %v", ErrInvalidPubKeyAttributes, err)
+		}
+		if eccParams.Scheme.Scheme != tpm20.TPMAlgECDSA {
+			return nil, fmt.Errorf("%w: unexpected eccParams.Scheme.Scheme in iakPubKey got %v, want %v", ErrInvalidPubKeyAttributes, eccParams.Scheme.Scheme, tpm20.TPMAlgECDSA)
+		}
+
+		if eccParams.CurveID == tpm20.TPMECCNistP384 {
+			if iakPubKey.NameAlg != tpm20.TPMAlgSHA384 {
+				return nil, fmt.Errorf("%w: TPMAlgECC with CurveID TPMECCNistP384 must use NameAlg TPMAlgSHA384, got %v", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
+			}
+			expectedPolicySecret = expectedPolicySecretSHA384
+		} else if eccParams.CurveID == tpm20.TPMECCNistP256 {
+			if iakPubKey.NameAlg != tpm20.TPMAlgSHA256 {
+				return nil, fmt.Errorf("%w: TPMAlgECC with CurveID TPMECCNistP256 must use NameAlg TPMAlgSHA256, got %v", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
+			}
+			expectedPolicySecret = expectedPolicySecretSHA256
+		} else {
+			return nil, fmt.Errorf("%w: unexpected eccParams.CurveID in iakPubKey got %v, want %v or %v", ErrInvalidPubKeyAttributes, eccParams.CurveID, tpm20.TPMECCNistP384, tpm20.TPMECCNistP256)
+		}
+	default:
+		return nil, fmt.Errorf("%w: IAKPub.Type (%v) must be TPMAlgRSA or TPMAlgECC", ErrInvalidPubKeyAttributes, iakPubKey.Type)
+	}
+
+	if !bytes.Equal(iakPubKey.AuthPolicy.Buffer, expectedPolicySecret) {
+		return nil, fmt.Errorf("%w: AuthPolicy mismatch", ErrInvalidPubKeyAttributes)
 	}
 
 	return iakPubKey, nil
@@ -634,7 +705,7 @@ func verifyECDSA(data []byte, sig *tpm20.TPMSSignatureECC, pubKey *tpm20.TPMTPub
 	return nil
 }
 
-// VerifyIdevidAttributes verifies the IDevID attributes and make sure they match the template provided.
+// VerifyIdevidAttributes verifies the IDevID attributes and makes sure they match the template provided.
 func (u *DefaultTPM20Utils) VerifyIdevidAttributes(idevidPub *tpm20.TPMTPublic, keyTemplate epb.KeyTemplate) error {
 	if idevidPub == nil {
 		return fmt.Errorf("%w: IDevID pub cannot be nil", ErrInputNil)
@@ -651,7 +722,7 @@ func (u *DefaultTPM20Utils) VerifyIdevidAttributes(idevidPub *tpm20.TPMTPublic, 
 		UserWithAuth:        true,
 		AdminWithPolicy:     true,
 	}
-	if err := verifyTPMTPublicAttributes(*idevidPub, expAttributes); err != nil {
+	if err := verifyTPMTPublicAttributes(idevidPub, expAttributes); err != nil {
 		return fmt.Errorf("failed to verify IDevID attributes: %w", err)
 	}
 	switch keyTemplate {

--- a/service/biz/tpm20_utils.go
+++ b/service/biz/tpm20_utils.go
@@ -516,17 +516,18 @@ func (u *DefaultTPM20Utils) VerifyIAKAttributes(iakPub []byte) (*tpm20.TPMTPubli
 			return nil, fmt.Errorf("%w: unexpected eccParams.Scheme.Scheme in iakPubKey got %v, want %v", ErrInvalidPubKeyAttributes, eccParams.Scheme.Scheme, tpm20.TPMAlgECDSA)
 		}
 
-		if eccParams.CurveID == tpm20.TPMECCNistP384 {
+		switch eccParams.CurveID {
+		case tpm20.TPMECCNistP384:
 			if iakPubKey.NameAlg != tpm20.TPMAlgSHA384 {
 				return nil, fmt.Errorf("%w: TPMAlgECC with CurveID TPMECCNistP384 must use NameAlg TPMAlgSHA384, got %v", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
 			}
 			expectedPolicySecret = expectedPolicySecretSHA384
-		} else if eccParams.CurveID == tpm20.TPMECCNistP256 {
+		case tpm20.TPMECCNistP256:
 			if iakPubKey.NameAlg != tpm20.TPMAlgSHA256 {
 				return nil, fmt.Errorf("%w: TPMAlgECC with CurveID TPMECCNistP256 must use NameAlg TPMAlgSHA256, got %v", ErrInvalidPubKeyAttributes, iakPubKey.NameAlg)
 			}
 			expectedPolicySecret = expectedPolicySecretSHA256
-		} else {
+		default:
 			return nil, fmt.Errorf("%w: unexpected eccParams.CurveID in iakPubKey got %v, want %v or %v", ErrInvalidPubKeyAttributes, eccParams.CurveID, tpm20.TPMECCNistP384, tpm20.TPMECCNistP256)
 		}
 	default:

--- a/service/biz/tpm20_utils_test.go
+++ b/service/biz/tpm20_utils_test.go
@@ -105,7 +105,7 @@ func TestVerifyTPMTPublicAttributes_Success(t *testing.T) {
 		ObjectAttributes: baseAttributes,
 	}
 
-	if err := verifyTPMTPublicAttributes(pubKeyWithBaseAttributes, baseAttributes); err != nil {
+	if err := verifyTPMTPublicAttributes(&pubKeyWithBaseAttributes, baseAttributes); err != nil {
 		t.Errorf("verifyTPMTPublicAttributes() returned an unexpected error: %v", err)
 	}
 }
@@ -210,7 +210,7 @@ func TestVerifyTPMTPublicAttributes_Failure(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := verifyTPMTPublicAttributes(tc.pubKey, tc.expected)
+			err := verifyTPMTPublicAttributes(&tc.pubKey, tc.expected)
 			if err == nil {
 				t.Error("verifyTPMTPublicAttributes() expected an error, but got nil")
 			}
@@ -228,23 +228,110 @@ func convertToTPM2BPublic(pub tpm20.TPMTPublic) []byte {
 func TestVerifyIAKAttributes_Success(t *testing.T) {
 	u := DefaultTPM20Utils{}
 
-	validIAKPub := validTPMTPublic
-	validIAKPub.ObjectAttributes = tpm20.TPMAObject{
-		FixedTPM:            true,
-		Restricted:          true,
-		SensitiveDataOrigin: true,
-		SignEncrypt:         true,
-		Decrypt:             false,
-		FixedParent:         true,
-		UserWithAuth:        true,
-		AdminWithPolicy:     true,
+	expectedPolicySecretSHA256 := []byte{
+		0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
+		0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
+		0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
+		0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
 	}
-	validIAKPub.NameAlg = tpm20.TPMAlgSHA256
-	validIAKPubBytes := convertToTPM2BPublic(validIAKPub)
+	expectedPolicySecretSHA384 := []byte{
+		0x12, 0x9D, 0x94, 0xEB, 0xF8, 0x45, 0x56, 0x65,
+		0x2C, 0x6E, 0xEF, 0x43, 0xBB, 0xB7, 0x57, 0x51,
+		0x2A, 0xC8, 0x7E, 0x52, 0xBE, 0x7B, 0x34, 0x9C,
+		0xA6, 0xCE, 0x4D, 0x82, 0x6F, 0x74, 0x9F, 0xCF,
+		0x67, 0x2F, 0x51, 0x71, 0x6C, 0x5C, 0xBB, 0x60,
+		0x5F, 0x31, 0x3B, 0xF3, 0x45, 0xAA, 0xB3, 0x12,
+	}
 
-	pubWithSHA384 := validIAKPub
-	pubWithSHA384.NameAlg = tpm20.TPMAlgSHA384
-	pubWithSHA384Bytes := convertToTPM2BPublic(pubWithSHA384)
+	validIAKPubECC := tpm20.TPMTPublic{
+		Type:    tpm20.TPMAlgECC,
+		NameAlg: tpm20.TPMAlgSHA384,
+		ObjectAttributes: tpm20.TPMAObject{
+			FixedTPM:            true,
+			Restricted:          true,
+			SensitiveDataOrigin: true,
+			SignEncrypt:         true,
+			Decrypt:             false,
+			FixedParent:         true,
+			UserWithAuth:        true,
+			AdminWithPolicy:     true,
+		},
+		AuthPolicy: tpm20.TPM2BDigest{
+			Buffer: expectedPolicySecretSHA384,
+		},
+		Parameters: tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+			Symmetric: tpm20.TPMTSymDefObject{Algorithm: tpm20.TPMAlgNull},
+			Scheme: tpm20.TPMTECCScheme{
+				Scheme: tpm20.TPMAlgECDSA,
+				Details: tpm20.NewTPMUAsymScheme(tpm20.TPMAlgECDSA, &tpm20.TPMSSigSchemeECDSA{
+					HashAlg: tpm20.TPMAlgSHA384,
+				}),
+			},
+			CurveID: tpm20.TPMECCNistP384,
+			KDF:     tpm20.TPMTKDFScheme{Scheme: tpm20.TPMAlgNull},
+		}),
+	}
+	validIAKECCBytes := convertToTPM2BPublic(validIAKPubECC)
+
+	validIAKPubECCP256 := tpm20.TPMTPublic{
+		Type:    tpm20.TPMAlgECC,
+		NameAlg: tpm20.TPMAlgSHA256,
+		ObjectAttributes: tpm20.TPMAObject{
+			FixedTPM:            true,
+			Restricted:          true,
+			SensitiveDataOrigin: true,
+			SignEncrypt:         true,
+			Decrypt:             false,
+			FixedParent:         true,
+			UserWithAuth:        true,
+			AdminWithPolicy:     true,
+		},
+		AuthPolicy: tpm20.TPM2BDigest{
+			Buffer: expectedPolicySecretSHA256,
+		},
+		Parameters: tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+			Symmetric: tpm20.TPMTSymDefObject{Algorithm: tpm20.TPMAlgNull},
+			Scheme: tpm20.TPMTECCScheme{
+				Scheme: tpm20.TPMAlgECDSA,
+				Details: tpm20.NewTPMUAsymScheme(tpm20.TPMAlgECDSA, &tpm20.TPMSSigSchemeECDSA{
+					HashAlg: tpm20.TPMAlgSHA256,
+				}),
+			},
+			CurveID: tpm20.TPMECCNistP256,
+			KDF:     tpm20.TPMTKDFScheme{Scheme: tpm20.TPMAlgNull},
+		}),
+	}
+	validIAKECCP256Bytes := convertToTPM2BPublic(validIAKPubECCP256)
+
+	validIAKPubRSA := tpm20.TPMTPublic{
+		Type:    tpm20.TPMAlgRSA,
+		NameAlg: tpm20.TPMAlgSHA256,
+		ObjectAttributes: tpm20.TPMAObject{
+			FixedTPM:            true,
+			Restricted:          true,
+			SensitiveDataOrigin: true,
+			SignEncrypt:         true,
+			Decrypt:             false,
+			FixedParent:         true,
+			UserWithAuth:        true,
+			AdminWithPolicy:     true,
+		},
+		AuthPolicy: tpm20.TPM2BDigest{
+			Buffer: expectedPolicySecretSHA256,
+		},
+		Parameters: tpm20.NewTPMUPublicParms(tpm20.TPMAlgRSA, &tpm20.TPMSRSAParms{
+			Symmetric: tpm20.TPMTSymDefObject{Algorithm: tpm20.TPMAlgNull},
+			Scheme: tpm20.TPMTRSAScheme{
+				Scheme: tpm20.TPMAlgRSASSA,
+				Details: tpm20.NewTPMUAsymScheme(tpm20.TPMAlgRSASSA, &tpm20.TPMSSigSchemeRSASSA{
+					HashAlg: tpm20.TPMAlgSHA256,
+				}),
+			},
+			KeyBits:  2048,
+			Exponent: 0,
+		}),
+	}
+	validIAKRSABytes := convertToTPM2BPublic(validIAKPubRSA)
 
 	tests := []struct {
 		name   string
@@ -252,14 +339,19 @@ func TestVerifyIAKAttributes_Success(t *testing.T) {
 		want   *tpm20.TPMTPublic
 	}{
 		{
-			name:   "Success",
-			iakPub: validIAKPubBytes,
-			want:   &validIAKPub,
+			name:   "Success ECC P-384",
+			iakPub: validIAKECCBytes,
+			want:   &validIAKPubECC,
 		},
 		{
-			name:   "Success SHA384",
-			iakPub: pubWithSHA384Bytes,
-			want:   &pubWithSHA384,
+			name:   "Success ECC P-256",
+			iakPub: validIAKECCP256Bytes,
+			want:   &validIAKPubECCP256,
+		},
+		{
+			name:   "Success RSA RSASSA",
+			iakPub: validIAKRSABytes,
+			want:   &validIAKPubRSA,
 		},
 	}
 
@@ -279,60 +371,220 @@ func TestVerifyIAKAttributes_Success(t *testing.T) {
 func TestVerifyIAKAttributes_Failure(t *testing.T) {
 	u := DefaultTPM20Utils{}
 
-	validIAKPub := validTPMTPublic
-	validIAKPub.ObjectAttributes = tpm20.TPMAObject{
-		FixedTPM:            true,
-		Restricted:          true,
-		SensitiveDataOrigin: true,
-		SignEncrypt:         true,
-		Decrypt:             false,
-		FixedParent:         true,
-		UserWithAuth:        true,
-		AdminWithPolicy:     true,
+	expectedPolicySecretSHA256 := []byte{
+		0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xB3, 0xF8,
+		0x1A, 0x90, 0xCC, 0x8D, 0x46, 0xA5, 0xD7, 0x24,
+		0xFD, 0x52, 0xD7, 0x6E, 0x06, 0x52, 0x0B, 0x64,
+		0xF2, 0xA1, 0xDA, 0x1B, 0x33, 0x14, 0x69, 0xAA,
 	}
-	validIAKPub.NameAlg = tpm20.TPMAlgSHA256
+	expectedPolicySecretSHA384 := []byte{
+		0x12, 0x9D, 0x94, 0xEB, 0xF8, 0x45, 0x56, 0x65,
+		0x2C, 0x6E, 0xEF, 0x43, 0xBB, 0xB7, 0x57, 0x51,
+		0x2A, 0xC8, 0x7E, 0x52, 0xBE, 0x7B, 0x34, 0x9C,
+		0xA6, 0xCE, 0x4D, 0x82, 0x6F, 0x74, 0x9F, 0xCF,
+		0x67, 0x2F, 0x51, 0x71, 0x6C, 0x5C, 0xBB, 0x60,
+		0x5F, 0x31, 0x3B, 0xF3, 0x45, 0xAA, 0xB3, 0x12,
+	}
+
+	validIAKPubECC := tpm20.TPMTPublic{
+		Type:    tpm20.TPMAlgECC,
+		NameAlg: tpm20.TPMAlgSHA384,
+		ObjectAttributes: tpm20.TPMAObject{
+			FixedTPM:            true,
+			Restricted:          true,
+			SensitiveDataOrigin: true,
+			SignEncrypt:         true,
+			Decrypt:             false,
+			FixedParent:         true,
+			UserWithAuth:        true,
+			AdminWithPolicy:     true,
+		},
+		AuthPolicy: tpm20.TPM2BDigest{
+			Buffer: expectedPolicySecretSHA384,
+		},
+		Parameters: tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+			Symmetric: tpm20.TPMTSymDefObject{Algorithm: tpm20.TPMAlgNull},
+			Scheme: tpm20.TPMTECCScheme{
+				Scheme: tpm20.TPMAlgECDSA,
+				Details: tpm20.NewTPMUAsymScheme(tpm20.TPMAlgECDSA, &tpm20.TPMSSigSchemeECDSA{
+					HashAlg: tpm20.TPMAlgSHA384,
+				}),
+			},
+			CurveID: tpm20.TPMECCNistP384,
+			KDF:     tpm20.TPMTKDFScheme{Scheme: tpm20.TPMAlgNull},
+		}),
+	}
+
+	validIAKPubRSA := tpm20.TPMTPublic{
+		Type:    tpm20.TPMAlgRSA,
+		NameAlg: tpm20.TPMAlgSHA256,
+		ObjectAttributes: tpm20.TPMAObject{
+			FixedTPM:            true,
+			Restricted:          true,
+			SensitiveDataOrigin: true,
+			SignEncrypt:         true,
+			Decrypt:             false,
+			FixedParent:         true,
+			UserWithAuth:        true,
+			AdminWithPolicy:     true,
+		},
+		AuthPolicy: tpm20.TPM2BDigest{
+			Buffer: expectedPolicySecretSHA256,
+		},
+		Parameters: tpm20.NewTPMUPublicParms(tpm20.TPMAlgRSA, &tpm20.TPMSRSAParms{
+			Symmetric: tpm20.TPMTSymDefObject{Algorithm: tpm20.TPMAlgNull},
+			Scheme: tpm20.TPMTRSAScheme{
+				Scheme: tpm20.TPMAlgRSASSA,
+				Details: tpm20.NewTPMUAsymScheme(tpm20.TPMAlgRSASSA, &tpm20.TPMSSigSchemeRSASSA{
+					HashAlg: tpm20.TPMAlgSHA256,
+				}),
+			},
+			KeyBits:  2048,
+			Exponent: 0,
+		}),
+	}
 
 	invalidUnmarshalBytes := []byte("invalid bytes")
 
-	pubWithBadAttr := validIAKPub
+	pubWithBadAttr := validIAKPubECC
 	pubWithBadAttr.ObjectAttributes.FixedTPM = false
 	pubWithBadAttrBytes := convertToTPM2BPublic(pubWithBadAttr)
 
-	pubWithBadUserWithAuth := validIAKPub
+	pubWithBadUserWithAuth := validIAKPubECC
 	pubWithBadUserWithAuth.ObjectAttributes.UserWithAuth = false
 	pubWithBadUserWithAuthBytes := convertToTPM2BPublic(pubWithBadUserWithAuth)
 
-	pubWithBadAdminWithPolicy := validIAKPub
+	pubWithBadAdminWithPolicy := validIAKPubECC
 	pubWithBadAdminWithPolicy.ObjectAttributes.AdminWithPolicy = false
 	pubWithBadAdminWithPolicyBytes := convertToTPM2BPublic(pubWithBadAdminWithPolicy)
 
-	pubWithBadNameAlg := validIAKPub
+	pubWithBadNameAlg := validIAKPubECC
 	pubWithBadNameAlg.NameAlg = tpm20.TPMAlgSHA1
 	pubWithBadNameAlgBytes := convertToTPM2BPublic(pubWithBadNameAlg)
 
+	pubWithWrongAuthPolicy := validIAKPubECC
+	pubWithWrongAuthPolicy.AuthPolicy = tpm20.TPM2BDigest{Buffer: []byte{0x01}}
+	pubWithWrongAuthPolicyBytes := convertToTPM2BPublic(pubWithWrongAuthPolicy)
+
+	eccWrongCurve := validIAKPubECC
+	eccWrongCurve.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+		CurveID: tpm20.TPMECCNistP256,
+		Scheme:  tpm20.TPMTECCScheme{Scheme: tpm20.TPMAlgECDSA},
+	})
+	eccWrongCurveBytes := convertToTPM2BPublic(eccWrongCurve)
+
+	eccWrongScheme := validIAKPubECC
+	eccWrongScheme.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+		CurveID: tpm20.TPMECCNistP384,
+		Scheme:  tpm20.TPMTECCScheme{Scheme: tpm20.TPMAlgNull},
+	})
+	eccWrongSchemeBytes := convertToTPM2BPublic(eccWrongScheme)
+
+	rsaWrongKeyBits := validIAKPubRSA
+	rsaWrongKeyBits.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgRSA, &tpm20.TPMSRSAParms{
+		KeyBits: 1024,
+		Scheme:  tpm20.TPMTRSAScheme{Scheme: tpm20.TPMAlgRSASSA},
+	})
+	rsaWrongKeyBitsBytes := convertToTPM2BPublic(rsaWrongKeyBits)
+
+	rsaWrongScheme := validIAKPubRSA
+	rsaWrongScheme.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgRSA, &tpm20.TPMSRSAParms{
+		KeyBits: 2048,
+		Scheme:  tpm20.TPMTRSAScheme{Scheme: tpm20.TPMAlgNull},
+	})
+	rsaWrongSchemeBytes := convertToTPM2BPublic(rsaWrongScheme)
+
+	rsaBadNameAlg := validIAKPubRSA
+	rsaBadNameAlg.NameAlg = tpm20.TPMAlgSHA384
+	rsaBadNameAlgBytes := convertToTPM2BPublic(rsaBadNameAlg)
+
+	pubWithUnsupportedType := validIAKPubRSA
+	pubWithUnsupportedType.Type = tpm20.TPMAlgSymCipher
+	pubWithUnsupportedType.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgSymCipher, &tpm20.TPMSSymCipherParms{
+		Sym: tpm20.TPMTSymDefObject{
+			Algorithm: tpm20.TPMAlgAES,
+			KeyBits:   tpm20.NewTPMUSymKeyBits(tpm20.TPMAlgAES, tpm20.TPMKeyBits(128)),
+			Mode:      tpm20.NewTPMUSymMode(tpm20.TPMAlgAES, tpm20.TPMAlgCFB),
+		},
+	})
+	pubWithUnsupportedTypeBytes := convertToTPM2BPublic(pubWithUnsupportedType)
+
+	eccUnsupportedCurve := validIAKPubECC
+	eccUnsupportedCurve.Parameters = tpm20.NewTPMUPublicParms(tpm20.TPMAlgECC, &tpm20.TPMSECCParms{
+		CurveID: tpm20.TPMECCNistP521,
+		Scheme:  tpm20.TPMTECCScheme{Scheme: tpm20.TPMAlgECDSA},
+	})
+	eccUnsupportedCurveBytes := convertToTPM2BPublic(eccUnsupportedCurve)
+
 	tests := []struct {
-		name   string
-		iakPub []byte
+		name    string
+		iakPub  []byte
+		wantErr error
 	}{
 		{
-			name:   "Unmarshal error",
-			iakPub: invalidUnmarshalBytes,
+			name:    "Unmarshal error",
+			iakPub:  invalidUnmarshalBytes,
+			wantErr: nil, // Error from tpm20.Unmarshal, not wrapping ErrInvalidPubKeyAttributes
 		},
 		{
-			name:   "Attribute mismatch",
-			iakPub: pubWithBadAttrBytes,
+			name:    "Attribute mismatch",
+			iakPub:  pubWithBadAttrBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
 		},
 		{
-			name:   "UserWithAuth mismatch",
-			iakPub: pubWithBadUserWithAuthBytes,
+			name:    "UserWithAuth mismatch",
+			iakPub:  pubWithBadUserWithAuthBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
 		},
 		{
-			name:   "AdminWithPolicy mismatch",
-			iakPub: pubWithBadAdminWithPolicyBytes,
+			name:    "AdminWithPolicy mismatch",
+			iakPub:  pubWithBadAdminWithPolicyBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
 		},
 		{
-			name:   "Invalid NameAlg",
-			iakPub: pubWithBadNameAlgBytes,
+			name:    "Invalid NameAlg",
+			iakPub:  pubWithBadNameAlgBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "Wrong AuthPolicy mismatch",
+			iakPub:  pubWithWrongAuthPolicyBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "ECC Wrong Curve mismatch",
+			iakPub:  eccWrongCurveBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "ECC Wrong Scheme mismatch",
+			iakPub:  eccWrongSchemeBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "RSA Wrong KeyBits mismatch",
+			iakPub:  rsaWrongKeyBitsBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "RSA Wrong Scheme mismatch",
+			iakPub:  rsaWrongSchemeBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "RSA Bad NameAlg mismatch",
+			iakPub:  rsaBadNameAlgBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "Unsupported Key Type mismatch",
+			iakPub:  pubWithUnsupportedTypeBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
+		},
+		{
+			name:    "ECC Unsupported Curve mismatch",
+			iakPub:  eccUnsupportedCurveBytes,
+			wantErr: ErrInvalidPubKeyAttributes,
 		},
 	}
 
@@ -340,7 +592,10 @@ func TestVerifyIAKAttributes_Failure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := u.VerifyIAKAttributes(tc.iakPub)
 			if err == nil {
-				t.Error("VerifyIAKAttributes() expected an error, but got nil")
+				t.Fatalf("VerifyIAKAttributes() expected an error, but got nil")
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("VerifyIAKAttributes() error = %v, want error wrapping %v", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Implement VerifyIAKAttributes to validate IAK public key attributes and AuthPolicy according to TCG specifications:
- Verify public key Type (RSA 2048-bit with RSASSA or ECC NIST P-256 / P-384 with ECDSA).
- Validate NameAlg matching (SHA256 for RSA-2048 and ECC P-256; SHA384 for ECC P-384).
- Check AuthPolicy digest against expected PolicyA SHA-256 (32 bytes) and SHA-384 (48 bytes) values.
- Add table-driven unit tests for VerifyIAKAttributes covering valid and invalid configurations.